### PR TITLE
CMake実行時に、HTS Engineがなくてもエラーで終了しないようにする

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,7 +105,7 @@ if(HTS_ENGINE_INCLUDE_DIR AND HTS_ENGINE_LIB)
   target_link_libraries(openjtalk ${HTS_ENGINE_LIB})
   include_directories(openjtalk ${HTS_ENGINE_INCLUDE_DIR})
 else()
-  message(FATAL_ERROR "Required HTSEngine not found")
+  message("Required HTSEngine not found")
 endif()
 
 # configuration for charset


### PR DESCRIPTION
題の通りです。
もしかしたら、メインにマージしない方がいいかもしれないです(pyopenjtalk等のため)。