### PR TITLE
safer version of text2mecab

### DIFF
--- a/src/bin/open_jtalk.c
+++ b/src/bin/open_jtalk.c
@@ -172,7 +172,10 @@ static int Open_JTalk_synthesis(Open_JTalk * open_jtalk, const char *txt, FILE *
    int result = 0;
    char buff[MAXBUFLEN];
 
-   text2mecab(buff, txt);
+   errno_t mecab_result = text2mecab(buff, MAXBUFLEN, txt);
+   if (mecab_result != 0) {
+      return 0;
+   }
    Mecab_analysis(&open_jtalk->mecab, buff);
    mecab2njd(&open_jtalk->njd, Mecab_get_feature(&open_jtalk->mecab),
              Mecab_get_size(&open_jtalk->mecab));

--- a/src/text2mecab/text2mecab.c
+++ b/src/text2mecab/text2mecab.c
@@ -92,54 +92,7 @@ static int strtopcmp(const char *str, const char *pattern)
    }
 }
 
-void text2mecab(char *output, const char *input)
-{
-   int i, j;
-   const int length = strlen(input);
-   const char *str;
-   int index = 0;
-   int s, e = -1;
-
-   for (s = 0; s < length;) {
-      str = &input[s];
-      /* search */
-      for (i = 0; text2mecab_conv_list[i] != NULL; i += 2) {
-         e = strtopcmp(str, text2mecab_conv_list[i]);
-         if (e != -1)
-            break;
-      }
-      if (e != -1) {
-         /* convert */
-         s += e;
-         str = text2mecab_conv_list[i + 1];
-         for (j = 0; str[j] != '\0'; j++)
-            output[index++] = str[j];
-      } else if (text2mecab_control_range[0] <= str[0] && str[0] <= text2mecab_control_range[1]) {
-         /* control character */
-         s++;
-      } else {
-         /* multi byte character */
-         e = -1;
-         for (j = 0; text2mecab_kanji_range[j] > 0; j += 3) {
-            if (text2mecab_kanji_range[j + 1] <= str[0] && text2mecab_kanji_range[j + 2] >= str[0]) {
-               e = text2mecab_kanji_range[j];
-               break;
-            }
-         }
-         if (e > 0) {
-            for (j = 0; j < e; j++)
-               output[index++] = input[s++];
-         } else {
-            /* unknown */
-            fprintf(stderr, "WARNING: text2mecab() in text2mecab.c: Wrong character.\n");
-            s++;
-         }
-      }
-   }
-   output[index] = '\0';
-}
-
-errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input)
+errno_t text2mecab(char *output, size_t sizeOfOutput, const char *input)
 {
    if (input == NULL || output == NULL || sizeOfOutput == 0)
       return EINVAL;

--- a/src/text2mecab/text2mecab.c
+++ b/src/text2mecab/text2mecab.c
@@ -151,7 +151,6 @@ errno_t text2mecab(char *output, size_t sizeOfOutput, const char *input)
    return 0;
 }
 
-
 TEXT2MECAB_C_END;
 
 #endif                          /* !TEXT2MECAB_C */

--- a/src/text2mecab/text2mecab.c
+++ b/src/text2mecab/text2mecab.c
@@ -141,17 +141,17 @@ void text2mecab(char *output, const char *input)
 
 errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input)
 {
-   int i, j;
-   const int length = strlen(input);
-   const char *str;
-   int index = 0;
-   int s, e = -1;
-
    if (output == NULL && sizeOfOutput > 0)
       return EINVAL;
 
    if (input == NULL)
       return EINVAL;
+
+   int i, j;
+   const int length = strlen(input);
+   const char *str;
+   int index = 0;
+   int s, e = -1;
 
    for (s = 0; s < length;) {
       str = &input[s];

--- a/src/text2mecab/text2mecab.c
+++ b/src/text2mecab/text2mecab.c
@@ -141,10 +141,7 @@ void text2mecab(char *output, const char *input)
 
 errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input)
 {
-   if (output == NULL && sizeOfOutput > 0)
-      return EINVAL;
-
-   if (input == NULL)
+   if (input == NULL || output == NULL || sizeOfOutput == 0)
       return EINVAL;
 
    int i, j;
@@ -165,8 +162,10 @@ errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input)
          /* convert */
          s += e;
          str = text2mecab_conv_list[i + 1];
-         if (index + strlen(str) >= sizeOfOutput)
+         if (index + strlen(str) >= sizeOfOutput) {
+            output[0] = '\0';
             return ERANGE;
+         }
          for (j = 0; str[j] != '\0'; j++)
             output[index++] = str[j];
       } else if (text2mecab_control_range[0] <= str[0] && str[0] <= text2mecab_control_range[1]) {
@@ -182,8 +181,10 @@ errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input)
             }
          }
          if (e > 0) {
-            if (index + e >= sizeOfOutput)
+            if (index + e >= sizeOfOutput) {
+               output[0] = '\0';
                return ERANGE;
+            }
             for (j = 0; j < e; j++)
                output[index++] = input[s++];
          } else {

--- a/src/text2mecab/text2mecab.h
+++ b/src/text2mecab/text2mecab.h
@@ -51,8 +51,7 @@
 
 TEXT2MECAB_H_START;
 
-void text2mecab(char *output, const char *input);
-errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input);
+errno_t text2mecab(char *output, size_t sizeOfOutput, const char *input);
 
 TEXT2MECAB_H_END;
 

--- a/src/text2mecab/text2mecab.h
+++ b/src/text2mecab/text2mecab.h
@@ -52,6 +52,7 @@
 TEXT2MECAB_H_START;
 
 void text2mecab(char *output, const char *input);
+errno_t text2mecab_s(char *output, size_t sizeOfOutput, const char *input);
 
 TEXT2MECAB_H_END;
 


### PR DESCRIPTION
cf. https://github.com/VOICEVOX/voicevox_engine/issues/384#issuecomment-1084870796

[CRT のセキュリティ機能](https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/security-features-in-the-crt?view=msvc-170) を参考に、
buffer overflowの危険性があるtext2mecabに対し、バッファーサイズを指定してそれをはみ出した場合エラーが返る `text2mecab_s` を実装した。
以下のような関数呼び出しをこれに置き換え、よりメモリ安全にする。

* https://github.com/VOICEVOX/pyopenjtalk/blob/a85521a0a0f298f08d9e9b24987b3c77eb4aaff5/pyopenjtalk/openjtalk.pyx#L168
* https://github.com/VOICEVOX/voicevox_core/blob/2bf979e27e1bf06bdc3187ae5e20ba3c63348c3b/core/src/engine/openjtalk.cpp#L18