### PR TITLE
C++の言語バージョンを明示的に指定

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 2.6)
 
 # set library version
 set(OPEN_JTALK_VERSION 1.10)
+set(CMAKE_CXX_STANDARD 14)
 set(PACKAGE "open_jtalk")
 set(PACKAGE_BUGREPORT "https://github.com/r9y9/open_jtalk/")
 set(PACKAGE_NAME "open_jtalk")


### PR DESCRIPTION
## 内容

CMakeLists.txt内でC++の言語バージョンを明示的にC++14と指定するようにしました

## その他

wasm向けビルドを試みていて発生した変更ですが、そもそもC++17で削除された機能(`std::binary_function`)に依存している箇所があるのでその他のターゲットに対しても破壊的変更にならないことを期待しています