### PR TITLE
feat: Windows環境で`FILE_FLAG_DELETE_ON_CLOSE`を付けて開かれている辞書を扱えるようにする

### DIFF
--- a/src/mecab/src/mmap.h
+++ b/src/mecab/src/mmap.h
@@ -105,7 +105,7 @@ template <class T> class Mmap {
     }
 
 #if 0 /* for Open JTalk */
-    hFile = ::CreateFileA(filename, mode1, FILE_SHARE_READ, 0,
+    hFile = ::CreateFileA(filename, mode1, FILE_SHARE_READ | FILE_SHARE_DELETE, 0,
 #else
     hFile = ::CreateFileW(WPATH(filename), mode1, FILE_SHARE_READ | FILE_SHARE_DELETE, 0,
 #endif

--- a/src/mecab/src/mmap.h
+++ b/src/mecab/src/mmap.h
@@ -107,7 +107,7 @@ template <class T> class Mmap {
 #if 0 /* for Open JTalk */
     hFile = ::CreateFileA(filename, mode1, FILE_SHARE_READ, 0,
 #else
-    hFile = ::CreateFileW(WPATH(filename), mode1, FILE_SHARE_READ, 0,
+    hFile = ::CreateFileW(WPATH(filename), mode1, FILE_SHARE_READ | FILE_SHARE_DELETE, 0,
 #endif
                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
     CHECK_FALSE(hFile != INVALID_HANDLE_VALUE)


### PR DESCRIPTION
## 内容

`CreateFileW`関数の`dwShareMode`に`FILE_SHARE_DELETE`を追加します。

これによりプロセス終了時や辞書切り替え時にユーザー辞書を自動的に削除することが可能になります。

詳細は https://github.com/VOICEVOX/voicevox_engine/issues/1347#issuecomment-2575737729 を参照。

## 関連 Issue

- ref https://github.com/VOICEVOX/voicevox_engine/issues/1347

## その他

[CreateFileW](https://learn.microsoft.com/ja-jp/windows/win32/api/fileapi/nf-fileapi-createfilew)
